### PR TITLE
Add light/dark/system theme support

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,6 +1,14 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="KK">
-  <circle cx="32" cy="32" r="30" fill="#fff" />
-  <g fill="#111" transform="translate(11.12 44.78) scale(.036 -.036)">
+  <style>
+    .favicon-bg { fill: #fff; }
+    .favicon-fg { fill: #111; }
+    @media (prefers-color-scheme: dark) {
+      .favicon-bg { fill: #202125; }
+      .favicon-fg { fill: #fff; }
+    }
+  </style>
+  <circle class="favicon-bg" cx="32" cy="32" r="30" />
+  <g class="favicon-fg" transform="translate(11.12 44.78) scale(.036 -.036)">
     <path d="M166 203L166 384L410 710L558 710ZM52 0L52 710L176 710L176 0ZM424 0L220 340L304 421L564 0Z" />
     <path transform="translate(600 0)" d="M166 203L166 384L410 710L558 710ZM52 0L52 710L176 710L176 0ZM424 0L220 340L304 421L564 0Z" />
   </g>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,14 +1,22 @@
+---
+import ThemeSwitcher from '@/components/ThemeSwitcher.tsx'
+---
+
 <footer
-  class="flex justify-between my-5 items-center container text-sm text-black/70 border-t border-black/10 pt-8"
+  class="flex justify-between my-5 items-center container text-sm text-muted-foreground border-t border-border pt-8"
 >
   <p>
     &copy; {new Date().getFullYear()} Kishan
   </p>
-  <a
-    rel="noopener noreferrer"
-    target="_blank"
-    href="https://github.com/kishanhitk/kishans.in"
-  >
-    View Source
-  </a>
+  <div class="flex items-center gap-4 sm:gap-5">
+    <a
+      class="transition-colors hover:text-foreground"
+      rel="noopener noreferrer"
+      target="_blank"
+      href="https://github.com/kishanhitk/kishans.in"
+    >
+      View Source
+    </a>
+    <ThemeSwitcher client:load />
+  </div>
 </footer>

--- a/src/components/ThemeSwitcher.tsx
+++ b/src/components/ThemeSwitcher.tsx
@@ -30,7 +30,7 @@ function applyTheme(theme: Theme) {
   document.documentElement.classList.toggle('dark', isDark)
   document
     .querySelector('meta[name="theme-color"]')
-    ?.setAttribute('content', isDark ? '#202125' : '#ffffff')
+    ?.setAttribute('content', isDark ? '#0a0a0a' : '#ffffff')
 }
 
 export default function ThemeSwitcher() {

--- a/src/components/ThemeSwitcher.tsx
+++ b/src/components/ThemeSwitcher.tsx
@@ -1,0 +1,87 @@
+import { Monitor, Moon, Sun } from 'lucide-react'
+import * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+type Theme = 'system' | 'light' | 'dark'
+
+const STORAGE_KEY = 'theme'
+
+const OPTIONS: { value: Theme; label: string; Icon: typeof Sun }[] = [
+  { value: 'system', label: 'System theme', Icon: Monitor },
+  { value: 'light', label: 'Light theme', Icon: Sun },
+  { value: 'dark', label: 'Dark theme', Icon: Moon },
+]
+
+function getStoredTheme(): Theme {
+  // Guard on `window`, not `localStorage`: Node 24 exposes a global
+  // `localStorage` stub during SSR whose methods throw, so a typeof-localStorage
+  // check passes on the server and then blows up on the first getItem call.
+  if (typeof window === 'undefined') return 'system'
+  const stored = localStorage.getItem(STORAGE_KEY)
+  return stored === 'light' || stored === 'dark' ? stored : 'system'
+}
+
+// Mirror of the inline <head> script in Layout.astro. Kept in sync so a click
+// updates the DOM immediately, before the next navigation re-runs the head script.
+function applyTheme(theme: Theme) {
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
+  const isDark = theme === 'dark' || (theme === 'system' && prefersDark)
+  document.documentElement.classList.toggle('dark', isDark)
+  document
+    .querySelector('meta[name="theme-color"]')
+    ?.setAttribute('content', isDark ? '#202125' : '#ffffff')
+}
+
+export default function ThemeSwitcher() {
+  const [theme, setTheme] = React.useState<Theme>(getStoredTheme)
+
+  React.useEffect(() => {
+    // Re-sync on hydration and when another tab changes the preference.
+    setTheme(getStoredTheme())
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === STORAGE_KEY) setTheme(getStoredTheme())
+    }
+    window.addEventListener('storage', onStorage)
+    return () => window.removeEventListener('storage', onStorage)
+  }, [])
+
+  const select = (next: Theme) => {
+    if (next === 'system') localStorage.removeItem(STORAGE_KEY)
+    else localStorage.setItem(STORAGE_KEY, next)
+    setTheme(next)
+    applyTheme(next)
+  }
+
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Theme"
+      className="inline-flex items-center gap-0.5 rounded-full border border-border p-0.5"
+    >
+      {OPTIONS.map(({ value, label, Icon }) => {
+        const active = theme === value
+        return (
+          <button
+            key={value}
+            type="button"
+            role="radio"
+            aria-checked={active}
+            aria-label={label}
+            title={label}
+            onClick={() => select(value)}
+            className={cn(
+              'flex h-7 w-7 items-center justify-center rounded-full transition-colors',
+              'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+              active
+                ? 'bg-secondary text-foreground'
+                : 'text-muted-foreground hover:text-foreground',
+            )}
+          >
+            <Icon className="h-4 w-4" strokeWidth={2} aria-hidden="true" />
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/ThemeSwitcher.tsx
+++ b/src/components/ThemeSwitcher.tsx
@@ -17,9 +17,11 @@ function getStoredTheme(): Theme {
   // Guard on `window`, not `localStorage`: Node 24 exposes a global
   // `localStorage` stub during SSR whose methods throw, so a typeof-localStorage
   // check passes on the server and then blows up on the first getItem call.
-  if (typeof window === 'undefined') return 'system'
+  if (typeof window === 'undefined') return 'light'
   const stored = localStorage.getItem(STORAGE_KEY)
-  return stored === 'light' || stored === 'dark' ? stored : 'system'
+  return stored === 'light' || stored === 'dark' || stored === 'system'
+    ? stored
+    : 'light'
 }
 
 // Mirror of the inline <head> script in Layout.astro. Kept in sync so a click
@@ -47,8 +49,9 @@ export default function ThemeSwitcher() {
   }, [])
 
   const select = (next: Theme) => {
-    if (next === 'system') localStorage.removeItem(STORAGE_KEY)
-    else localStorage.setItem(STORAGE_KEY, next)
+    // Persist all three states explicitly: a missing key is the light default,
+    // so "system" must be stored rather than implied by absence.
+    localStorage.setItem(STORAGE_KEY, next)
     setTheme(next)
     applyTheme(next)
   }

--- a/src/components/blogs/BlogHead.astro
+++ b/src/components/blogs/BlogHead.astro
@@ -21,7 +21,7 @@ const userLocalDate = new Date(publishedAt).toLocaleDateString('en-US', {
     <h1 class="dark:text-white" transition:name={`title-${slug}`}>
       {title}
     </h1>
-    <p class="-mt-5 text-gray-500">
+    <p class="-mt-5 text-muted-foreground">
       Posted: {userLocalDate}
     </p>
   </div>

--- a/src/components/contact/Cal.astro
+++ b/src/components/contact/Cal.astro
@@ -2,6 +2,29 @@
 <div style="width:100%;height:570px;overflow:scroll" id="my-cal-inline"></div>
 <script is:inline>
   (function () {
+    var themeObserver;
+
+    // Mirror the site theme (the .dark class on <html>) rather than the OS,
+    // so the widget follows the in-app switcher, not just prefers-color-scheme.
+    function currentTheme() {
+      return document.documentElement.classList.contains("dark")
+        ? "dark"
+        : "light";
+    }
+
+    function applyCalTheme() {
+      if (!window.Cal || !Cal.ns || !Cal.ns["15min"]) return;
+      var theme = currentTheme();
+      Cal.ns["15min"]("ui", {
+        theme: theme,
+        styles: {
+          branding: { brandColor: theme === "dark" ? "#ffffff" : "#000000" },
+        },
+        hideEventTypeDetails: false,
+        layout: "month_view",
+      });
+    }
+
     function initCal() {
       var container = document.getElementById("my-cal-inline");
       if (!container) return;
@@ -46,17 +69,22 @@
             p(cal, ar);
           };
       })(window, "https://app.cal.com/embed/embed.js", "init");
+
+      var theme = currentTheme();
       Cal("init", "15min", { origin: "https://cal.com" });
       Cal.ns["15min"]("inline", {
         elementOrSelector: "#my-cal-inline",
-        config: { layout: "month_view", theme: "light" },
+        config: { layout: "month_view", theme: theme },
         calLink: "jst-kishan/15min",
       });
-      Cal.ns["15min"]("ui", {
-        theme: "light",
-        styles: { branding: { brandColor: "#000000" } },
-        hideEventTypeDetails: false,
-        layout: "month_view",
+      applyCalTheme();
+
+      // Re-theme the widget whenever the site theme toggles.
+      if (themeObserver) themeObserver.disconnect();
+      themeObserver = new MutationObserver(applyCalTheme);
+      themeObserver.observe(document.documentElement, {
+        attributes: true,
+        attributeFilter: ["class"],
       });
     }
 

--- a/src/components/home/HomeProjects.astro
+++ b/src/components/home/HomeProjects.astro
@@ -66,7 +66,7 @@ const projects = [
 <div class="my-8 sm:my-10" id="projects">
   <div class="container" id="projects-header">
     <h3 class="text-xl sm:text-2xl font-semibold">Personal Projects</h3>
-    <h4 class="text-lg sm:text-xl text-black/70 mt-3 sm:mt-4">
+    <h4 class="text-lg sm:text-xl text-foreground/70 mt-3 sm:mt-4">
       Building things is my therapy.
     </h4>
   </div>

--- a/src/components/home/HomepageHero.astro
+++ b/src/components/home/HomepageHero.astro
@@ -5,14 +5,14 @@ import { Button } from '@/components/ui/button'
 ---
 
 <div class="container">
-  <h1 class="text-3xl sm:text-4xl font-bold text-gray-900" id="hero-title">
+  <h1 class="text-3xl sm:text-4xl font-bold text-foreground" id="hero-title">
     Hello, I'm Kishan.
   </h1>
-  <h2 class="text-xl sm:text-2xl text-gray-500 mt-2" id="hero-subtitle">
+  <h2 class="text-xl sm:text-2xl text-muted-foreground mt-2" id="hero-subtitle">
     A product engineer building AI agent systems.
   </h2>
   <p
-    class="text-lg sm:text-xl mt-4 sm:mt-5 text-gray-700"
+    class="text-lg sm:text-xl mt-4 sm:mt-5 text-foreground/80"
     id="hero-description"
   >
     I like building useful products end-to-end, from agent workflows and

--- a/src/components/home/ProjectCard.astro
+++ b/src/components/home/ProjectCard.astro
@@ -15,7 +15,7 @@ const { title, subtitle, description, image, link } = Astro.props
 
 <a
   href={link}
-  class="rounded-xl overflow-hidden p-6 sm:p-10 bg-secondary m-4 group"
+  class="rounded-xl overflow-hidden p-6 sm:p-10 bg-secondary dark:bg-white/[0.03] m-4 group"
   target="_blank"
   rel="noreferrer"
 >

--- a/src/components/home/ProjectCard.astro
+++ b/src/components/home/ProjectCard.astro
@@ -15,7 +15,7 @@ const { title, subtitle, description, image, link } = Astro.props
 
 <a
   href={link}
-  class="rounded-xl overflow-hidden p-6 sm:p-10 bg-gray-50 m-4 group"
+  class="rounded-xl overflow-hidden p-6 sm:p-10 bg-secondary m-4 group"
   target="_blank"
   rel="noreferrer"
 >
@@ -29,9 +29,9 @@ const { title, subtitle, description, image, link } = Astro.props
   <div class="mt-4">
     <h5 class="text-lg sm:text-xl font-semibold">
       {title}
-      <span class="text-sm text-black/60 ml-2">{subtitle}</span>
+      <span class="text-sm text-foreground/60 ml-2">{subtitle}</span>
     </h5>
-    <p class="text-sm sm:text-base text-black/70 mt-1">
+    <p class="text-sm sm:text-base text-foreground/70 mt-1">
       {description}
     </p>
   </div>

--- a/src/components/home/WritingItem.astro
+++ b/src/components/home/WritingItem.astro
@@ -23,7 +23,7 @@ const formattedDate = new Date(post.publishedAt).toLocaleDateString('en-US', {
   <h3 class="mb-1 text-2xl font-semibold">
     {post.title}
   </h3>
-  <p class="text-sm text-gray-500 my-2 font-mono">
+  <p class="text-sm text-muted-foreground my-2 font-mono">
     Published on {formattedDate}
   </p>
   <p class="mb-5">{post.brief.slice(0, 100)}...</p>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -29,6 +29,35 @@ const siteURL = new URL(Astro.url.pathname, Astro.site || 'https://kishans.in')
     <ClientRouter />
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+    <!-- Theme init: applies before paint to avoid a flash of the wrong theme.
+         Runs on first load, on every View Transition swap, and on OS theme change. -->
+    <script is:inline>
+      (() => {
+        const STORAGE_KEY = "theme";
+        const applyTheme = () => {
+          const stored = localStorage.getItem(STORAGE_KEY);
+          const prefersDark = window.matchMedia(
+            "(prefers-color-scheme: dark)",
+          ).matches;
+          const isDark =
+            stored === "dark" || (stored !== "light" && prefersDark);
+          document.documentElement.classList.toggle("dark", isDark);
+          document
+            .querySelector('meta[name="theme-color"]')
+            ?.setAttribute("content", isDark ? "#202125" : "#ffffff");
+        };
+        applyTheme();
+        // Re-apply after Astro swaps the DOM on client-side navigation.
+        document.addEventListener("astro:after-swap", applyTheme);
+        // Live-update while following the OS (no explicit preference stored).
+        window
+          .matchMedia("(prefers-color-scheme: dark)")
+          .addEventListener("change", () => {
+            if (!localStorage.getItem(STORAGE_KEY)) applyTheme();
+          });
+      })();
+    </script>
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="alternate icon" type="image/png" href="/favicon.ico" />
     <meta name="generator" content={Astro.generator} />

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -40,8 +40,10 @@ const siteURL = new URL(Astro.url.pathname, Astro.site || 'https://kishans.in')
           const prefersDark = window.matchMedia(
             "(prefers-color-scheme: dark)",
           ).matches;
+          // Default (no stored choice) is light; only follow the OS when the
+          // visitor has explicitly picked "system".
           const isDark =
-            stored === "dark" || (stored !== "light" && prefersDark);
+            stored === "dark" || (stored === "system" && prefersDark);
           document.documentElement.classList.toggle("dark", isDark);
           document
             .querySelector('meta[name="theme-color"]')
@@ -54,7 +56,7 @@ const siteURL = new URL(Astro.url.pathname, Astro.site || 'https://kishans.in')
         window
           .matchMedia("(prefers-color-scheme: dark)")
           .addEventListener("change", () => {
-            if (!localStorage.getItem(STORAGE_KEY)) applyTheme();
+            if (localStorage.getItem(STORAGE_KEY) === "system") applyTheme();
           });
       })();
     </script>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -45,7 +45,7 @@ const siteURL = new URL(Astro.url.pathname, Astro.site || 'https://kishans.in')
           document.documentElement.classList.toggle("dark", isDark);
           document
             .querySelector('meta[name="theme-color"]')
-            ?.setAttribute("content", isDark ? "#202125" : "#ffffff");
+            ?.setAttribute("content", isDark ? "#0a0a0a" : "#ffffff");
         };
         applyTheme();
         // Re-apply after Astro swaps the DOM on client-side navigation.
@@ -105,8 +105,10 @@ const siteURL = new URL(Astro.url.pathname, Astro.site || 'https://kishans.in')
 
 <style>
   html.dark {
-    background-color: #202125;
-    color: #fff;
+    /* Track the same token the body paints, so margin-collapse at the top
+       of the page doesn't reveal a mismatched grey bar. */
+    background-color: hsl(var(--background));
+    color: hsl(var(--foreground));
   }
   html {
     scroll-behavior: smooth;

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -6,9 +6,9 @@ import Layout from '@/layouts/Layout.astro'
 
 <Layout title="About">
   <div class="mb-12 sm:mb-20 min-h-screen container">
-    <h1 class="text-3xl sm:text-4xl font-bold text-gray-900">About Me</h1>
+    <h1 class="text-3xl sm:text-4xl font-bold text-foreground">About Me</h1>
     <Separator className="my-5 sm:my-7" />
-    <p class="text-lg sm:text-xl text-gray-600 leading-7 sm:leading-9">
+    <p class="text-lg sm:text-xl text-muted-foreground leading-7 sm:leading-9">
       Hi there, I'm Kishan. I'm a product engineer who likes taking fuzzy
       ideas all the way to shipped products. My work sits around AI agents,
       evaluation systems, developer tools, native apps, and full-stack products
@@ -34,14 +34,14 @@ import Layout from '@/layouts/Layout.astro'
       <br />If you’re interested in collaborating or have a project in mind,
       feel free to reach out to me at&nbsp;<a
         href="mailto:hello@kishans.in?cc=kishansharma1231@gmail.com&subject=Hey%20Kishan%2C%20we%20have%20some%20exciting%20opportunity%20for%20you"
-        class="text-black underline"
+        class="text-foreground underline"
       >
         hello@kishans.in.
       </a>
     </p>
 
     <h2
-      class="text-xl sm:text-2xl font-bold text-gray-900 mt-8 sm:mt-10 mb-4 sm:mb-5"
+      class="text-xl sm:text-2xl font-bold text-foreground mt-8 sm:mt-10 mb-4 sm:mb-5"
     >
       Experience
     </h2>
@@ -54,10 +54,10 @@ import Layout from '@/layouts/Layout.astro'
         />
         <div>
           <h3 class="text-xl sm:text-2xl font-semibold">Plivo</h3>
-          <p class="text-gray-600 my-1 mb-2 text-base sm:text-lg">
+          <p class="text-muted-foreground my-1 mb-2 text-base sm:text-lg">
             Software Engineer II
           </p>
-          <p class="text-sm text-gray-500 font-mono">Nov 2024 → Present</p>
+          <p class="text-sm text-muted-foreground font-mono">Nov 2024 → Present</p>
         </div>
       </li>
       <Separator className="my-5 sm:my-7" />
@@ -69,10 +69,10 @@ import Layout from '@/layouts/Layout.astro'
         />
         <div>
           <h3 class="text-xl sm:text-2xl font-semibold">Quinence</h3>
-          <p class="text-gray-600 my-1 mb-2 text-base sm:text-lg">
+          <p class="text-muted-foreground my-1 mb-2 text-base sm:text-lg">
             Software Engineer
           </p>
-          <p class="text-sm text-gray-500 font-mono">June 2022 → Nov 2024</p>
+          <p class="text-sm text-muted-foreground font-mono">June 2022 → Nov 2024</p>
         </div>
       </li>
       <Separator className="my-5 sm:my-7" />
@@ -84,10 +84,10 @@ import Layout from '@/layouts/Layout.astro'
         />
         <div>
           <h3 class="text-xl sm:text-2xl font-semibold">Increff</h3>
-          <p class="text-gray-600 my-1 mb-2 text-base sm:text-lg">
+          <p class="text-muted-foreground my-1 mb-2 text-base sm:text-lg">
             Software Developer (UI) Intern
           </p>
-          <p class="text-sm text-gray-500 font-mono">January 2022 → May 2022</p>
+          <p class="text-sm text-muted-foreground font-mono">January 2022 → May 2022</p>
         </div>
       </li>
       <Separator className="my-5 sm:my-7" />
@@ -100,10 +100,10 @@ import Layout from '@/layouts/Layout.astro'
         />
         <div>
           <h3 class="text-xl sm:text-2xl font-semibold">NCR Technologies</h3>
-          <p class="text-gray-600 my-1 mb-2 text-base sm:text-lg">
+          <p class="text-muted-foreground my-1 mb-2 text-base sm:text-lg">
             Software Developer Intern
           </p>
-          <p class="text-sm text-gray-500 font-mono">May 2021 → Aug 2021</p>
+          <p class="text-sm text-muted-foreground font-mono">May 2021 → Aug 2021</p>
         </div>
       </li>
       <Separator className="my-5 sm:my-7" />
@@ -116,10 +116,10 @@ import Layout from '@/layouts/Layout.astro'
         />
         <div>
           <h3 class="text-xl sm:text-2xl font-semibold">Digimall</h3>
-          <p class="text-gray-600 my-1 mb-2 text-base sm:text-lg">
+          <p class="text-muted-foreground my-1 mb-2 text-base sm:text-lg">
             Software Developer Intern
           </p>
-          <p class="text-sm text-gray-500 font-mono">March 2021 → May 2021</p>
+          <p class="text-sm text-muted-foreground font-mono">March 2021 → May 2021</p>
         </div>
       </li>
     </ul>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -38,6 +38,12 @@ import Layout from '@/layouts/Layout.astro'
       >
         hello@kishans.in.
       </a>
+      &nbsp;You can also take a look at my&nbsp;<a
+        href="/resume"
+        class="text-foreground underline"
+      >
+        resume</a
+      >.
     </p>
 
     <h2

--- a/src/pages/blogs/[slug].astro
+++ b/src/pages/blogs/[slug].astro
@@ -21,7 +21,7 @@ const blog = await getPostBySlug(slug, 'blog.kishans.in')
   <div class="container">
     <BlogHead post={blog} />
     <div
-      class="prose dark:prose-invert prose-lg sm:prose-xl prose-zinc prose-code:font-mono prose-pre:bg-black text-zinc-600 max-w-full"
+      class="prose dark:prose-invert prose-lg sm:prose-xl prose-zinc prose-code:font-mono prose-pre:bg-black text-foreground/80 max-w-full"
       set:html={blog.content.html}
     />
   </div>

--- a/src/pages/blogs/index.astro
+++ b/src/pages/blogs/index.astro
@@ -11,7 +11,7 @@ const posts = await getAllPostByUsername('blog.kishans.in')
 
 <Layout title="Blogs">
   <div class="container mb-12 sm:mb-20 min-h-screen">
-    <h1 class="text-3xl sm:text-4xl font-bold text-gray-900">
+    <h1 class="text-3xl sm:text-4xl font-bold text-foreground">
       Recent Writings
     </h1>
 

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -7,8 +7,8 @@ import Layout from '@/layouts/Layout.astro'
 <Layout title="Contact">
   <div class="mb-12 sm:mb-20 min-h-screen">
     <div class="container mb-8 sm:mb-12">
-      <h1 class="text-3xl sm:text-4xl font-bold text-gray-900">Contact</h1>
-      <p class="text-lg sm:text-xl text-gray-700 mt-3">
+      <h1 class="text-3xl sm:text-4xl font-bold text-foreground">Contact</h1>
+      <p class="text-lg sm:text-xl text-foreground/80 mt-3">
         Book a slot with me to discuss your project or just to say hi.
       </p>
     </div>
@@ -17,37 +17,37 @@ import Layout from '@/layouts/Layout.astro'
     </div>
 
     <div class="container">
-      <p class="text-lg sm:text-xl text-gray-700">
+      <p class="text-lg sm:text-xl text-foreground/80">
         Or, you can reach me using one of these.
       </p>
       <div class="grid grid-cols-1 sm:grid-cols-2 my-6 sm:my-8 gap-4 sm:gap-6">
         <a
           href="mailto:hello@kishans.in?cc=kishansharma1231@gmail.com&subject=Hey%20Kishan%2C%20we%20have%20some%20exciting%20opportunity%20for%20you"
-          class="text-base sm:text-lg text-gray-700"
+          class="text-base sm:text-lg text-foreground/80"
         >
           <div>
-            <h2 class="text-xl sm:text-2xl font-bold text-gray-900">Email</h2>
+            <h2 class="text-xl sm:text-2xl font-bold text-foreground">Email</h2>
             hello@kishans.in
           </div>
         </a>
         <a href="https://twitter.com/jst_kishan" target="_blank">
           <div>
-            <h2 class="text-xl sm:text-2xl font-bold text-gray-900">Twitter</h2>
-            <p class="text-gray-700">@jst_kishan</p>
+            <h2 class="text-xl sm:text-2xl font-bold text-foreground">Twitter</h2>
+            <p class="text-foreground/80">@jst_kishan</p>
           </div>
         </a>
         <a href="https://github.com/kishanhitk" target="_blank">
           <div>
-            <h2 class="text-xl sm:text-2xl font-bold text-gray-900">Github</h2>
-            <p class="text-gray-700">git/kishanhitk</p>
+            <h2 class="text-xl sm:text-2xl font-bold text-foreground">Github</h2>
+            <p class="text-foreground/80">git/kishanhitk</p>
           </div>
         </a>
         <a href="https://www.linkedin.com/in/kishanju/" target="_blank">
           <div>
-            <h2 class="text-xl sm:text-2xl font-bold text-gray-900">
+            <h2 class="text-xl sm:text-2xl font-bold text-foreground">
               LinkedIn
             </h2>
-            <p class="text-gray-700">in/kishanju</p>
+            <p class="text-foreground/80">in/kishanju</p>
           </div>
         </a>
       </div>


### PR DESCRIPTION
## Summary

Adds light / dark / system theme support with a switcher in the footer, styled after tailwindcss.com. **Default is light**; visitors can opt into Dark or System.

## What's included

- **Theme switcher** (`ThemeSwitcher.tsx`) — segmented System / Light / Dark control (lucide icons) at the bottom of every page, `client:load` island, accessible `radiogroup`.
- **No-flash init** — a blocking inline script in `Layout.astro` applies the theme before first paint, re-applies on every Astro View Transition (`astro:after-swap`), and live-updates on OS change only when the visitor has chosen System.
- **Dark-mode-ready pages** — hardcoded light-only classes across home, about, contact, and blog pages converted to the semantic tokens in `global.css`.
- **Theme-aware favicon** — `favicon.svg` carries a `prefers-color-scheme` media query.
- **Theme-aware cal.com embed** — the contact widget re-themes live via a MutationObserver on `<html>`.
- **Subtle resume link** on the about page → `/resume`.

## Persistence model

`localStorage.theme` is `light` | `dark` | `system`, persisted explicitly. A **missing key resolves to light** (the default), so System is stored rather than implied by absence.

## Notes / decisions

- Grey-bar-at-top fix: `html.dark` background now tracks `hsl(var(--background))` instead of a hardcoded grey, so header margin-collapse no longer reveals a mismatched strip.
- Project cards use `bg-secondary dark:bg-white/[0.03]` so the dark surface is a subtle lift, not a bright block.
- Favicon follows the OS (tab-bar context), not the in-app toggle, by design.
- `404.astro` (full-bleed image, no Layout) and `demo.astro` (fixed OG banner) intentionally excluded.

## Testing

- `bun run build` passes; all 10 routes prerender.

🤖 Generated with [Claude Code](https://claude.com/claude-code)